### PR TITLE
do not install firebase globally

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -135,7 +135,7 @@ if [ -z "${app}" ] ; then
 fi
 
 # # Install Firebase
-npm install -g firebase-tools
+npm install firebase-tools
 
 # Export Firebase Token
 if [ -n "${firebase_token}" ] ; then


### PR DESCRIPTION
Since some Bitrise stack seems have firebase pre-installed at /local/usr/bin, install firebase-tools globally will cause this step failed with error: npm ERR! code EEXIST

Refer to issue: https://github.com/guness/bitrise-step-firebase-app-distribution/issues/12