### PR TITLE
Adding release notes file option

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -86,6 +86,7 @@ echo_details "* service_credentials_file: $service_credentials_file"
 echo_details "* app_path: $app_path"
 echo_details "* app: $app"
 echo_details "* release_notes: $release_notes"
+echo_details "* release_notes_file: $release_notes_file"
 echo_details "* testers: $testers"
 echo_details "* groups: $groups"
 echo_details "* flags: $flags"
@@ -156,6 +157,10 @@ submit_cmd="$submit_cmd --app \"${app}\""
 ## Optional params
 if [ -n "${release_notes}" ] ; then
     submit_cmd="$submit_cmd --release-notes \"${release_notes}\""
+fi
+
+if [ -n "${release_notes_file}" ] ; then
+    submit_cmd="$submit_cmd --release-notes-file \"${release_notes_file}\""
 fi
 
 if [ -n "${testers}" ] ; then

--- a/step.yml
+++ b/step.yml
@@ -78,6 +78,12 @@ inputs:
       description: |
         Release notes for this build.
       is_required: false
+  - release_notes_file:
+    opts:
+      title: Release Notes File
+      description: |
+        File that contains release notes for this build.
+      is_required: false
   - testers:
     opts:
       title: Testers


### PR DESCRIPTION
We typically generate a release notes file and send that file along when uploading to Crashlytics Beta. Now that we have to migrate to Firebase App Distribution, I'd like the ability to continue to do that using this Bitrise step since it is an available option. 