### PR TITLE
feat: Add step option to enable firebase tools upgrade.

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -91,6 +91,7 @@ echo_details "* testers: $testers"
 echo_details "* groups: $groups"
 echo_details "* flags: $flags"
 echo_details "* is_debug: $is_debug"
+echo_details "* upgrade_firebase_tools: $upgrade_firebase_tools"
 
 echo
 
@@ -140,7 +141,11 @@ if [ ! -z "${release_notes_file}" ] && [ ! -f "${release_notes_file}" ] ; then
 fi
 
 # Install Firebase
-curl -sL firebase.tools | bash
+if [ "${upgrade_firebase_tools}" = true ] ; then
+    curl -sL firebase.tools | upgrade=true bash
+else
+    curl -sL firebase.tools | bash
+fi
 
 # Export Firebase Token
 if [ -n "${firebase_token}" ] ; then

--- a/step.yml
+++ b/step.yml
@@ -112,22 +112,21 @@ inputs:
         Additional flags to be appended to Firebase command.
         ie. you can specify file inputs for groups, and testers.
       is_required: false
+  - upgrade_firebase_tools: "false"
+    opts:
+      title: "Enable Firebase Tools Upgrade"
+      summary: Firebase tools will be upgraded if enabled.
+      description: Firebase tools will be upgraded if enabled.
+      is_required: true
+      value_options:
+        - "false"
+        - "true"
   - is_debug: "false"
     opts:
       category: Debug
       title: "Enable Debug Mode"
       summary: The step will print more verbose logs if enabled.
       description: The step will print more verbose logs if enabled.
-      is_required: true
-      value_options:
-        - "false"
-        - "true"
-  - upgrade_firebase_tools: "false"
-    opts:
-      category: Firebase Tools
-      title: "Enable Firebase Tools Upgrade"
-      summary: Firebase tools will be upgraded if enabled.
-      description: Firebase tools will be upgraded if enabled.
       is_required: true
       value_options:
         - "false"

--- a/step.yml
+++ b/step.yml
@@ -113,12 +113,22 @@ inputs:
         ie. you can specify file inputs for groups, and testers.
       is_required: false
   - is_debug: "false"
-    opts: 
+    opts:
       category: Debug
       title: "Enable Debug Mode"
       summary: The step will print more verbose logs if enabled.
       description: The step will print more verbose logs if enabled.
       is_required: true
       value_options:
-      - "false"
-      - "true"
+        - "false"
+        - "true"
+  - upgrade_firebase_tools: "false"
+    opts:
+      category: Firebase Tools
+      title: "Enable Firebase Tools Upgrade"
+      summary: Firebase tools will be upgraded if enabled.
+      description: Firebase tools will be upgraded if enabled.
+      is_required: true
+      value_options:
+        - "false"
+        - "true"


### PR DESCRIPTION
We need an option to force upgrade firebase tools version.
Current bitrise step installs v7.12.0 but we need the latest version v7.15.1 with the fix for this issue:
https://github.com/firebase/firebase-tools/issues/2016