### PR TITLE
Add check for FIREBASE_TOKEN existence

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -168,8 +168,12 @@ if [ -z "${firebase_token}" ] ; then
     fi
 fi
 
+if [ -n "${FIREBASE_TOKEN}" ]  && [ -n "${service_credentials_file}" ]; then
+    echo_warn "Both authentication methods are defined: Firebase Token (via FIREBASE_TOKEN environment variable) and Service Credentials Field, one is enough."
+fi
+
 if [ -n "${firebase_token}" ]  && [ -n "${service_credentials_file}" ]; then
-    echo_info "Both authentication inputs are defined: Firebase Token and Service Credentials Field, one is enough."
+    echo_warn "Both authentication inputs are defined: Firebase Token and Service Credentials Field, one is enough."
 fi
 
 if [ -z "${app}" ] ; then


### PR DESCRIPTION
Warn when both token (either as input or environment variable) and service credentials are defined at the same time