### PR TITLE
fix for issue #40

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -213,7 +213,7 @@ if [ -n "${firebase_token}" ] ; then
 fi
 
 if [ -n "${release_notes}" ] ; then
-    submit_cmd="$submit_cmd --release-notes \"$(escape "$release_notes")\""
+    submit_cmd="$submit_cmd --release-notes=\"$(escape "$release_notes")\""
 fi
 
 if [ -n "${release_notes_file}" ] && [ -f "${release_notes_file}" ] ; then


### PR DESCRIPTION
Applying suggestion by @ColtonIdle to "escape" leading `-` in the contents of the release notes.
Link to issue: https://github.com/guness/bitrise-step-firebase-app-distribution/issues/40