### PR TITLE
Fix For Issue #55 - Race Condition

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -116,7 +116,6 @@ echo_details "* groups: $groups"
 echo_details "* flags: $flags"
 echo_details "* is_debug: $is_debug"
 echo_details "* upgrade_firebase_tools: $upgrade_firebase_tools"
-echo_details "ANTHONYS VERSION"
 
 echo
 

--- a/step.sh
+++ b/step.sh
@@ -119,6 +119,11 @@ echo_details "* upgrade_firebase_tools: $upgrade_firebase_tools"
 
 echo
 
+# Export Service Credentials File
+if [ -n "${service_credentials_file}" ] ; then
+    export GOOGLE_APPLICATION_CREDENTIALS="${service_credentials_file}"
+fi
+
 if [ -z "${app_path}" ] ; then
     echo_fail "App path for APK, AAB or IPA is not defined"
 fi
@@ -194,11 +199,6 @@ if [ "${upgrade_firebase_tools}" = true ] ; then
     curl -sL firebase.tools | upgrade=true bash
 else
     curl -sL firebase.tools | bash
-fi
-
-# Export Service Credentials File
-if [ -n "${service_credentials_file}" ] ; then
-    export GOOGLE_APPLICATION_CREDENTIALS="${service_credentials_file}"
 fi
 
 # Deploy

--- a/step.sh
+++ b/step.sh
@@ -116,6 +116,7 @@ echo_details "* groups: $groups"
 echo_details "* flags: $flags"
 echo_details "* is_debug: $is_debug"
 echo_details "* upgrade_firebase_tools: $upgrade_firebase_tools"
+echo_details "ANTHONYS VERSION"
 
 echo
 


### PR DESCRIPTION
Recently I added Firebase App Distribution to my project **and chose to use Service Account Credentials to authorize** as using a token will be soon deprecated. I noticed that I started to face the same problem outlined in Issue #55, as this step would fail consistently for the reason 

`Error: Failed to authenticate, have you run firebase login?`

To use this step, I had to manually run export GOOGLE_APPLICATION_CREDENTIALS= at an earlier state in my pipeline.

I was very surprised to see that the error would still occur even though this step has the command that exports the environment variable. **I believe the cause of this error is a race condition between the time the environment variable is exported and the firebase deployment command is ran**.

I've moved the export command earlier in the script, and tested it on my project on Bitrise, and it now passes consistently, without having to manually set this environment variable in my pipeline