### PR TITLE
Added release ID output

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -97,6 +97,20 @@ function truncate_release_notes {
     fi
 }
 
+function extract_release_id {
+    local output="$1"
+    local release_id
+
+    release_id=$(echo "$output" | grep -Eo '/releases/[a-zA-Z0-9]+' | head -n1 | awk -F'/' '{print $3}')
+
+    if [ -z "$release_id" ]; then
+        echo_warn "Release ID not found in the output."
+    else
+        echo_info "Release ID: $release_id"
+        envman add --key FIREBASE_APP_DISTRIBUTION_RELEASE_ID --value "$release_id"
+    fi
+}
+
 #=======================================
 # Main
 #=======================================
@@ -240,7 +254,13 @@ fi
 echo_details "$submit_cmd"
 echo
 
-eval "${submit_cmd}"
+# Execute the command and capture the output
+output=$(eval "${submit_cmd}" 2>&1)
+
+echo "$output"
+
+# Set output variables
+extract_release_id "$output"
 
 if [ $? -eq 0 ] ; then
     echo_done "Success"

--- a/step.sh
+++ b/step.sh
@@ -168,8 +168,12 @@ if [ -z "${firebase_token}" ] ; then
     fi
 fi
 
+if [ -n "${FIREBASE_TOKEN}" ]  && [ -n "${service_credentials_file}" ]; then
+    echo_warn "Both authentication methods are defined: Firebase Token (via FIREBASE_TOKEN environment variable) and Service Credentials Field, one is enough."
+fi
+
 if [ -n "${firebase_token}" ]  && [ -n "${service_credentials_file}" ]; then
-    echo_info "Both authentication inputs are defined: Firebase Token and Service Credentials Field, one is enough."
+    echo_warn "Both authentication inputs are defined: Firebase Token and Service Credentials Field, one is enough."
 fi
 
 if [ -z "${app}" ] ; then

--- a/step.yml
+++ b/step.yml
@@ -137,3 +137,9 @@ inputs:
       value_options:
         - "false"
         - "true"
+
+outputs:
+  - FIREBASE_APP_DISTRIBUTION_RELEASE_ID: null
+    opts:
+      title: Firebase App Distribution Release ID
+      summary: The Firebase App Distribution Release ID of the uploaded build.


### PR DESCRIPTION
The PR aims to add output variable `FIREBASE_APP_DISTRIBUTION_RELEASE_ID`

It should solve #65 and #54 as the value can be used to build testing and console URLs.

Testing URL example:
```bash
https://appdistribution.firebase.google.com/testerapps/${APP_ID}/releases/${FIREBASE_APP_DISTRIBUTION_RELEASE_ID}
```
