### PR TITLE
Added option to skip Firebase tools installation

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -199,7 +199,11 @@ fi
 if [ "${upgrade_firebase_tools}" = true ] ; then
     curl -sL firebase.tools | upgrade=true bash
 else
-    curl -sL firebase.tools | bash
+    if command -v firebase >/dev/null 2>&1 ; then
+        echo_info "Firebase CLI is already installed. Skipping installation."
+    else
+        curl -sL firebase.tools | bash
+    fi
 fi
 
 # Deploy

--- a/step.sh
+++ b/step.sh
@@ -168,8 +168,12 @@ if [ -z "${firebase_token}" ] ; then
     fi
 fi
 
+if [ -n "${FIREBASE_TOKEN}" ]  && [ -n "${service_credentials_file}" ]; then
+    echo_warn "Both authentication methods are defined: Firebase Token (via FIREBASE_TOKEN environment variable) and Service Credentials Field, one is enough."
+fi
+
 if [ -n "${firebase_token}" ]  && [ -n "${service_credentials_file}" ]; then
-    echo_info "Both authentication inputs are defined: Firebase Token and Service Credentials Field, one is enough."
+    echo_warn "Both authentication inputs are defined: Firebase Token and Service Credentials Field, one is enough."
 fi
 
 if [ -z "${app}" ] ; then


### PR DESCRIPTION
Added an input option to skip the installation of Firebase tools.

The `curl -sL firebase.tools | bash` command rans `sudo`, which prompts for a password when running in non-Bitrise environments. This new option allows you to skip this step and use your own method to install Firebase CLI if needed.